### PR TITLE
Improve date handling for weekends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+dist/
+.eggs/
+*.egg-info/
+.env
+.vscode/
+.idea/
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Yahoo-Scraping
+
+このリポジトリには、Yahoo!ファイナンスから投資信託の月末基準価額を取得してExcelに記録するスクリプト `TestJP_5.py` が含まれています。
+
+## 必要環境
+- Python 3.8 以上
+- Google Chrome および ChromeDriver
+- `selenium`、`openpyxl` パッケージ
+
+依存パッケージは以下でインストールできます。
+
+```bash
+pip install selenium openpyxl
+```
+
+ChromeDriver は Chrome のバージョンに合わせてダウンロードし、`PATH` が通った場所に配置してください。
+
+## 使い方
+1. `JP_Stocks.xlsx` をリポジトリのルートに配置します。"Price" シートの A 列に証券コード、1 行目の B 列以降に `yy/mm` 形式の年月を記入してください。
+2. スクリプトを実行します。
+
+```bash
+python TestJP_5.py
+```
+
+処理が完了すると Excel ファイルに月末(休日の場合は直前の平日)の基準価額が書き込まれ、上書き保存されます。
+
+## 注意
+- Web からデータを取得するため、実行にはインターネット接続が必要です。
+- Yahoo!ファイナンスのページ構成変更により動作しなくなる可能性があります。

--- a/TestJP_5.py
+++ b/TestJP_5.py
@@ -1,0 +1,128 @@
+import datetime
+import re
+import time
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+import openpyxl
+
+# Excelファイルのパスとシート名を設定
+FILE_PATH = "JP_Stocks.xlsx"
+SHEET_NAME = "Price"
+
+
+def load_sheet(path: str, sheet: str):
+    """Excel ファイルとシートを読み込む"""
+    wb = openpyxl.load_workbook(path)
+    return wb, wb[sheet]
+
+
+def parse_dates(ws):
+    """1 行目の yy/mm 形式から月末日を取得"""
+    dates = []
+    for col in range(2, ws.max_column + 1):
+        value = ws.cell(row=1, column=col).value
+        if not value:
+            break
+        m = re.match(r"(\d{2})/(\d{2})", str(value))
+        if m:
+            yy, mm = map(int, m.groups())
+            year = 2000 + yy
+            # 月末日を計算し、休日なら直前の平日にずらす
+            d = datetime.date(year, mm, 1).replace(day=28) + datetime.timedelta(days=4)
+            last_day = d - datetime.timedelta(days=d.day)
+            while last_day.weekday() >= 5:  # 5=土,6=日
+                last_day -= datetime.timedelta(days=1)
+            dates.append((col, last_day))
+    return dates
+
+
+def parse_tickers(ws):
+    """1 列目から銘柄コードを取得"""
+    tickers = []
+    for row in range(2, ws.max_row + 1):
+        code = ws.cell(row=row, column=1).value
+        if code:
+            tickers.append((row, str(code).strip()))
+    return tickers
+
+
+def init_driver():
+    """Chrome WebDriver を初期化"""
+    options = Options()
+    # options.add_argument('--headless')  # 必要に応じて有効化
+    options.add_argument('--disable-gpu')
+    options.add_argument('--no-sandbox')
+    driver = webdriver.Chrome(options=options)
+    return driver
+
+
+def fetch_price(driver, code: str, date: datetime.date):
+    """指定日付の基準価額を取得"""
+    url = f"https://finance.yahoo.co.jp/quote/{code}/history"
+    driver.get(url)
+
+    try:
+        # 月間タブを開く
+        period_button = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//button[.='月間']"))
+        )
+        period_button.click()
+        time.sleep(1)
+
+        # 日付を入力（readonly 属性を外して値を直接設定）
+        start_input = driver.find_element(By.ID, "historyTermFromDate")
+        end_input = driver.find_element(By.ID, "historyTermToDate")
+
+        date_str = date.strftime("%Y/%m/%d")
+        for elem in (start_input, end_input):
+            driver.execute_script("arguments[0].removeAttribute('readonly');", elem)
+            driver.execute_script("arguments[0].value = arguments[1];", elem, date_str)
+
+        # 更新ボタンを押下
+        update_btn = driver.find_element(By.XPATH, "//button[.='更新']")
+        update_btn.click()
+
+        # テーブル表示を待機
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "table"))
+        )
+        time.sleep(1)
+
+        # 終値セルから数値取得
+        price_cell = driver.find_element(By.CSS_SELECTOR, "table tbody tr td:nth-child(2)")
+        value_str = price_cell.text.strip().replace(",", "")
+        return int(float(value_str))
+    except Exception as e:
+        print(f"{code} {date}: データ取得失敗 - {e}")
+        return None
+
+
+def main():
+    wb, ws = load_sheet(FILE_PATH, SHEET_NAME)
+    dates = parse_dates(ws)
+    tickers = parse_tickers(ws)
+    driver = init_driver()
+
+    for row, code in tickers:
+        for col, dt in dates:
+            cell = ws.cell(row=row, column=col)
+            if cell.value is not None:
+                continue  # 既に値がある場合はスキップ
+            price = fetch_price(driver, code, dt)
+            if price is not None:
+                cell.value = price
+                print(f"{code} {dt}: {price}円")
+            time.sleep(1)  # アクセス過多防止
+
+    driver.quit()
+    wb.save(FILE_PATH)
+    print("✅ 全データ取得完了＆Excel保存！")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adjust month-end date to previous weekday if the last day is a weekend
- set values in read-only date fields via JavaScript
- document weekday handling in README

## Testing
- `python -m py_compile TestJP_5.py`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d414fc3a08326b65eb0de5c942862